### PR TITLE
[Windows] Fix build Omaha can not find .exe file

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -60,12 +60,26 @@ action("build_omaha_installer") {
     "--brave_full_version=$_brave_full_version",
   ]
 
+  _tagged_langs = []
+  if (tag_lang == "" || tag_lang == "all") {
+    _tagged_langs = [
+      "en",
+      "vi",
+    ]
+  } else {
+    _tagged_langs = string_split(tag_lang, ",")
+  }
+
   outputs = [
-    "$root_out_dir/$brave_stub_installer_exe",
-    "$root_out_dir/$brave_standalone_installer_exe",
-    "$root_out_dir/$brave_silent_installer_exe",
     "$root_out_dir/$brave_untagged_installer_exe",
   ]
+  foreach(_lang, _tagged_langs) {
+    outputs += [
+      "$root_out_dir/lang/$_lang/$brave_stub_installer_exe",
+      "$root_out_dir/lang/$_lang/$brave_standalone_installer_exe",
+      "$root_out_dir/lang/$_lang/$brave_silent_installer_exe",
+    ]
+  }
 
   deps = [
     "//brave/build/win:create_signed_installer",


### PR DESCRIPTION
- Issue: FAILED: 0e1df946-c1c5-45e0-b9d2-26dd2a3f20c2 "./HerondBrowserSetup_143_2_5_9_1_7.exe" ACTION //brave/vendor/omaha:build_omaha_installer(//build/toolchain/win:win_clang_x64) err: missing local outputs out/release-x64/HerondBrowserSetup_143_2_5_9_1_7.exe: CreateFile E:/action-runner-upgrade/_work/herond-browser/herond-browser/src/out/release-x64/HerondBrowserSetup_143_2_5_9_1_7.exe: The system cannot find the file specified.
- The script build_omaha.py will gen the .exe in the path: root_out_dir/lang/<lang>. But GN declared outputs: still expect root_out_dir/... So the path will be wrong when build build_omaha_installer
- Solution: read _tagged_langs from build's args, insert them into the output.

<!-- [[DO NOT UPDATE]] THIS IS DEFAULT TEMPLATE, IT MAY BE OVERRIDE -->
<!-- Add link to the issue below that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [ ] There is a ticket for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels to the associated issue
- [ ] Checked the PR locally
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Code follows the style guide
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] All relevant documentation has been updated

## Test Plan: